### PR TITLE
add aurorafusion to dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - tofu
   - omas
   - xbout
+  - aurorafusion
   - pip:
     - turbopy
     - freegs


### PR DESCRIPTION
`aurorafusion` is a package for particle transport, neutrals and radiation in plasmas, discussed in a contributed presentation during hack week.

Docs: https://aurora-fusion.readthedocs.io/en/latest/